### PR TITLE
Readability of Equations in Dark Mode

### DIFF
--- a/Assignment_1/README.md
+++ b/Assignment_1/README.md
@@ -154,9 +154,9 @@ by applying the following rules:
     <!-- Replace the old set of faces `F` with `F''`. -->
  2. Move each vertex `v` of the old vertices `V` to a new position `p` by averaging `v` with the positions of its neighboring vertices in the *original* mesh.
     If `v` has valence `n` and its neighbors in the original mesh `(V, F)` are `v_0`, `v_1`, ...,  `v_n`, then the update rule is<br/>
-    ![](https://latex.codecogs.com/svg.latex?p=(1-a_n)v&plus;\frac{a_n}{n}\sum\limits_{i=0}^{n-1}v_i)<br/>
+    ![](https://latex.codecogs.com/png.latex?\fg_gray%20p=(1-a_n)v&plus;\frac{a_n}{n}\sum\limits_{i=0}^{n-1}v_i)<br/>
     <!-- p = (1-a_n) v + \frac{a_n}{n}\sum\limits_{i=0}^{n-1} v_i -->where<br/>
-    ![](https://latex.codecogs.com/svg.latex?a_n=\frac{4-2\cos\left(\frac{2\pi}{n}\right)}{9}.)<br/>
+    ![](https://latex.codecogs.com/png.latex?\fg_gray%20a_n=\frac{4-2\cos\left(\frac{2\pi}{n}\right)}{9}.)<br/>
     <!-- a_n=\frac{4-2\cos\left(\frac{2\pi}{n}\right)}{9} -->
     The vertex set of the subdivided mesh is then `V' = [P, M]`, where `P` is the concatenation of the new positions `p` for all vertices.
   3. Replace the `F''` with a new set of faces `F'` such that the edges connecting the newly added points `M` to `P`


### PR DESCRIPTION
Hi Prof.,
The equations were black on black in dark mode making them unreadable.
While this change makes it a little worse in light mode, it makes the eq. visible in both dark and light mode.
SVG does not support `fg_<color>`, hence changed to PNG.